### PR TITLE
feat: rethink agent demand logic

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,10 +24,10 @@ jobs:
       run: dotnet build --configuration Release --no-restore ./src/ADOAgentOrchestrator.csproj
       
     - name: Test
-      run: dotnet test  ./tests/ADOAgentOrchestrator.Tests.csproj --collect:"XPlat Code Coverage"
+      run: dotnet test --collect:"XPlat Code Coverage" --logger "junit;LogFilePath=TestResults.xml"
 
     - name: Publish Test Results
       uses: EnricoMi/publish-unit-test-result-action/composite@v1
       if: always()
       with:
-        files: "tests/TestResults/**/*.xml"
+        files: "tests/TestResults.xml"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,4 +24,10 @@ jobs:
       run: dotnet build --configuration Release --no-restore ./src/ADOAgentOrchestrator.csproj
       
     - name: Test
-      run: dotnet test  ./tests/ADOAgentOrchestrator.Tests.csproj
+      run: dotnet test  ./tests/ADOAgentOrchestrator.Tests.csproj --collect:"XPlat Code Coverage"
+
+    - name: Publish Test Results
+      uses: EnricoMi/publish-unit-test-result-action/composite@v1
+      if: always()
+      with:
+        files: "tests/TestResults/**/*.xml"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Azure Pipelines - Kubernetes Orchestrator
+![example branch parameter](https://github.com/akanieski/ado-agent-orchestrator/actions/workflows/ci.yaml/badge.svg?branch=feature/rethink-agent-demand-logic
 Many enterprise customers run their own Kubernetes clusters either on-premise or in managed kubernetes environments in the cloud. Azure DevOps Services and Server agents can run from containers hosted in these Kubernetes clusters, but what if you do not want to run your agents 24/7? What if you need to be able to scale the number of agents dynamically as pipelines jobs are queued?
 
 This project provides an application that can monitor a configurable set of agent pools, when pipeline jobs are queued up it will automagically provision Kubernetes Jobs for each job that is queued up. The Kubernetes Jobs will run and process only a single Pipelines Job and then be cleaned up by Kubernetes. 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Azure Pipelines - Kubernetes Orchestrator
-![example branch parameter](https://github.com/akanieski/ado-agent-orchestrator/actions/workflows/ci.yaml/badge.svg?branch=feature/rethink-agent-demand-logic
+[![Continuous Integration](https://github.com/akanieski/ado-agent-orchestrator/actions/workflows/ci.yaml/badge.svg?branch=feature%2Frethink-agent-demand-logic)](https://github.com/akanieski/ado-agent-orchestrator/actions/workflows/ci.yaml)
+
 Many enterprise customers run their own Kubernetes clusters either on-premise or in managed kubernetes environments in the cloud. Azure DevOps Services and Server agents can run from containers hosted in these Kubernetes clusters, but what if you do not want to run your agents 24/7? What if you need to be able to scale the number of agents dynamically as pipelines jobs are queued?
 
 This project provides an application that can monitor a configurable set of agent pools, when pipeline jobs are queued up it will automagically provision Kubernetes Jobs for each job that is queued up. The Kubernetes Jobs will run and process only a single Pipelines Job and then be cleaned up by Kubernetes. 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Azure Pipelines - Kubernetes Orchestrator
-[![Continuous Integration](https://github.com/akanieski/ado-agent-orchestrator/actions/workflows/ci.yaml/badge.svg?branch=feature%2Frethink-agent-demand-logic)](https://github.com/akanieski/ado-agent-orchestrator/actions/workflows/ci.yaml)
+[![Continuous Integration](https://github.com/akanieski/ado-agent-orchestrator/actions/workflows/ci.yaml/badge.svg?branch=master)](https://github.com/akanieski/ado-agent-orchestrator/actions/workflows/ci.yaml)
 
 Many enterprise customers run their own Kubernetes clusters either on-premise or in managed kubernetes environments in the cloud. Azure DevOps Services and Server agents can run from containers hosted in these Kubernetes clusters, but what if you do not want to run your agents 24/7? What if you need to be able to scale the number of agents dynamically as pipelines jobs are queued?
 

--- a/src/Azure/ACIAgentHostService.cs
+++ b/src/Azure/ACIAgentHostService.cs
@@ -66,16 +66,13 @@ public class ACIAgentHostService : BaseHostService, IAgentHostService
                 })
                 .Attach()
             .CreateAsync();
-            
-        WorkerAgent worker = null;
-        _workers.Add(worker = new WorkerAgent()
+        return new WorkerAgent()
         {
             Id = name,
             IsBusy = false,
             IsProvisioning = true,
             ProvisioningStart = DateTime.UtcNow
-        });
-        return worker;
+        };
     }
 
     public Task Initialize()

--- a/src/Azure/ACIAgentHostService.cs
+++ b/src/Azure/ACIAgentHostService.cs
@@ -6,8 +6,8 @@ using System.Net.Http.Headers;
 using Azure.Extensions.Identity;
 using FluentAzure = Microsoft.Azure.Management.Fluent.Azure;
 using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
-/*
-public class ACIAgentHostService : IAgentHostService
+
+public class ACIAgentHostService : BaseHostService, IAgentHostService
 {
     private string _jobPrefix;
     private string _azSub;
@@ -19,8 +19,8 @@ public class ACIAgentHostService : IAgentHostService
     private string _orgPat;
     private string _os;
     private string _azRegion;
-    private IAzure _az;
-    public ACIAgentHostService(IConfiguration config)
+
+    public ACIAgentHostService(IConfiguration config, string poolName)
     {
         _azSub = config.GetValue<string>("AZ_SUBSCRIPTION_ID");
         _azRegion = config.GetValue<string>("AZ_REGION");
@@ -28,10 +28,11 @@ public class ACIAgentHostService : IAgentHostService
         _azResourceGroup = config.GetValue<string>("AZ_RESOURCE_GROUP");
         _jobImage = config.GetValue<string>("JOB_IMAGE");
         _azEnvironment = config.GetValue<string>("AZ_ENVIRONMENT", "AzureGlobalCloud");
-        _jobPrefix = config.GetValue<string>("JOB_PREFIX", "agent-job-");
+        _jobPrefix = config.GetValue<string>("JOB_PREFIX", "agent-job");
         _orgUrl = config.GetValue<string>("ORG_URL");
         _orgPat = config.GetValue<string>("ORG_PAT");
         _os = config.GetValue<string>("JOB_OS", "linux").ToLower();
+        _poolName = poolName;
 
         if (_azSub == null) throw new ArgumentNullException("Azure subscription is required.");
         if (_azRegion == null) throw new ArgumentNullException("Azure region is required.");
@@ -39,53 +40,50 @@ public class ACIAgentHostService : IAgentHostService
         if (_azResourceGroup == null) throw new ArgumentNullException("Azure resource group is required.");
     }
 
-    private string FormatJobName(string requestId) => $"{_jobPrefix}{requestId}";
-
-    public async Task<bool> IsJobProvisioned(string requestId) =>
-        (await GetAzureContext().ContainerGroups.GetByIdAsync(
-            $"/subscriptions/{_azSub}/resourceGroups/{_azResourceGroup}/providers/Microsoft.ContainerInstance/containerGroups/{FormatJobName(requestId)}"))
-            != null;
+    private string FormatJobName() => $"{_jobPrefix}-{_poolName}-{Guid.NewGuid().ToString().Substring(0,4)}".ToLower();
 
     private IAzure GetAzureContext() =>
         FluentAzure
         .Authenticate(new AzureIdentityFluentCredentialAdapter(_azTenant, AzureEnvironment.FromName(_azEnvironment)))
         .WithSubscription(_azSub);
 
-    public async Task StartAgent(string requestId, string agentPool)
+    public override async Task<WorkerAgent> StartAgent()
     {
-        dynamic instance = GetAzureContext()
+        var name = FormatJobName();
+        var instance = await GetAzureContext()
             .ContainerGroups
-            .Define(FormatJobName(requestId))
+            .Define(FormatJobName())
             .WithRegion(Region.Create(_azRegion))
-            .WithExistingResourceGroup(_azResourceGroup);
-        
-        if (_os == "linux")
-        {
-            instance = instance.WithLinux();
-        }
-        else
-        {
-            instance = instance.WithWindows();
-        }
-
-        await instance.WithPublicImageRegistryOnly()
+            .WithExistingResourceGroup(_azResourceGroup)
+            .WithLinux()
+            .WithPublicImageRegistryOnly()
             .WithoutVolume()
-            .DefineContainerInstance(FormatJobName(requestId) + "-" + Guid.NewGuid().ToString().Substring(0, 4))
+            .DefineContainerInstance(name)
                 .WithImage(_jobImage)
                 .WithoutPorts()
                 .WithEnvironmentVariables(new Dictionary<string, string>()
                 {
                     { "AZP_URL", _orgUrl },
                     { "AZP_TOKEN", _orgPat },
-                    { "AZP_POOL",  agentPool },
+                    { "AZP_POOL",  _poolName },
                 })
                 .Attach()
             .CreateAsync();
-
+            
+        WorkerAgent worker = null;
+        _workers.Add(worker = new WorkerAgent()
+        {
+            Id = name,
+            IsBusy = false,
+            IsProvisioning = true,
+            ProvisioningStart = DateTime.UtcNow
+        });
+        return worker;
     }
+
     public Task Initialize()
     {
         return Task.CompletedTask;
     }
+
 }
-*/

--- a/src/Azure/ACIAgentHostService.cs
+++ b/src/Azure/ACIAgentHostService.cs
@@ -9,7 +9,6 @@ using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
 
 public class ACIAgentHostService : BaseHostService, IAgentHostService
 {
-    private string _jobPrefix;
     private string _azSub;
     private string _azTenant;
     private string _jobImage;
@@ -39,8 +38,6 @@ public class ACIAgentHostService : BaseHostService, IAgentHostService
         if (_azTenant == null) throw new ArgumentNullException("Azure tenant id is required.");
         if (_azResourceGroup == null) throw new ArgumentNullException("Azure resource group is required.");
     }
-
-    private string FormatJobName() => $"{_jobPrefix}-{_poolName}-{Guid.NewGuid().ToString().Substring(0,4)}".ToLower();
 
     private IAzure GetAzureContext() =>
         FluentAzure

--- a/src/Azure/ACIAgentHostService.cs
+++ b/src/Azure/ACIAgentHostService.cs
@@ -6,7 +6,7 @@ using System.Net.Http.Headers;
 using Azure.Extensions.Identity;
 using FluentAzure = Microsoft.Azure.Management.Fluent.Azure;
 using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
-
+/*
 public class ACIAgentHostService : IAgentHostService
 {
     private string _jobPrefix;
@@ -39,9 +39,9 @@ public class ACIAgentHostService : IAgentHostService
         if (_azResourceGroup == null) throw new ArgumentNullException("Azure resource group is required.");
     }
 
-    private string FormatJobName(long requestId) => $"{_jobPrefix}{requestId}";
+    private string FormatJobName(string requestId) => $"{_jobPrefix}{requestId}";
 
-    public async Task<bool> IsJobProvisioned(long requestId) =>
+    public async Task<bool> IsJobProvisioned(string requestId) =>
         (await GetAzureContext().ContainerGroups.GetByIdAsync(
             $"/subscriptions/{_azSub}/resourceGroups/{_azResourceGroup}/providers/Microsoft.ContainerInstance/containerGroups/{FormatJobName(requestId)}"))
             != null;
@@ -51,7 +51,7 @@ public class ACIAgentHostService : IAgentHostService
         .Authenticate(new AzureIdentityFluentCredentialAdapter(_azTenant, AzureEnvironment.FromName(_azEnvironment)))
         .WithSubscription(_azSub);
 
-    public async Task StartAgent(long requestId, string agentPool)
+    public async Task StartAgent(string requestId, string agentPool)
     {
         dynamic instance = GetAzureContext()
             .ContainerGroups
@@ -88,3 +88,4 @@ public class ACIAgentHostService : IAgentHostService
         return Task.CompletedTask;
     }
 }
+*/

--- a/src/BaseHostService.cs
+++ b/src/BaseHostService.cs
@@ -1,0 +1,69 @@
+public class BaseHostService
+{
+    protected List<WorkerAgent> _workers = new List<WorkerAgent>();
+    protected TimeSpan AGENT_PROVISIONING_TIMEOUT = TimeSpan.FromMinutes(5);
+    protected string _poolName;
+
+    public int ScheduledWorkerCount => _workers.Count();
+    public virtual async Task UpdateDemand(int agentDemand)
+    {
+        // There appears to be X Job Requests that are not currently assigned to an agent that is idle
+        // Let's assess the number of "Idle" or Provisioning agents vs the demand
+        var netAgentDemand = agentDemand - _workers.Count(w => w.IsProvisioning || !w.IsBusy);
+        if (netAgentDemand > 0)
+        {
+            // Not enough Agents to meet demand.. lets provision some!
+            for (var i = 0; i < netAgentDemand; i++)
+            {
+                try
+                {
+                    var worker = await StartAgent();
+                    Console.WriteLine($"Provisioned agent worker {worker.Id} to meet demand of {netAgentDemand}");
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine($"Failed to provision agent." + Environment.NewLine + ex.ToString());
+                }
+            }
+        }
+        else if (netAgentDemand < 0)
+        {
+            // We have too many agents in relation to the demand.. lets cut back
+            Console.WriteLine($"There are currently over provisioned {netAgentDemand} agents");
+        }
+    }
+
+    public virtual Task UpdateWorkersState(IEnumerable<WorkerAgent> updatedAgents)
+    {
+        // Remove any agents that have left the pool (as long as they're not provisioning and they're not present in updatedAgents)
+        // We exclude provisioning because sometimes it takes multiple seconds to provision an agent
+        List<WorkerAgent> toDelete = new List<WorkerAgent>();
+        foreach (var existingWorker in _workers)
+        {
+            // Check if Provisioning has taken too long
+            if (existingWorker.IsProvisioning && (DateTime.UtcNow - existingWorker.ProvisioningStart).TotalMinutes >= AGENT_PROVISIONING_TIMEOUT.TotalMinutes)
+            {
+                toDelete.Add(existingWorker);
+                continue;
+            }
+
+            // Check if agent no longer exists in the pool
+            var updatedAgent = updatedAgents.FirstOrDefault(a => a.Id.StartsWith(existingWorker.Id));
+            if (updatedAgent == null) // We use StartsWith here b/c K8s job pods have a suffix appended
+            {
+                toDelete.Add(existingWorker);
+                continue;
+            }
+
+            // Update existing WorkerAgent with updated state info
+            existingWorker.Id = updatedAgent.Id;
+            existingWorker.IsBusy = updatedAgent.IsBusy;
+            updatedAgent.IsProvisioning = false;
+        }
+        // Add any new workers that made their way into the pool
+        _workers.AddRange(updatedAgents.Where(u => !_workers.Any(w => w.Id.StartsWith(u.Id))));
+
+        return Task.CompletedTask;
+    }
+    public virtual Task<WorkerAgent> StartAgent() => throw new NotImplementedException();
+}

--- a/src/BaseHostService.cs
+++ b/src/BaseHostService.cs
@@ -3,8 +3,10 @@ public class BaseHostService
     protected List<WorkerAgent> _workers = new List<WorkerAgent>();
     protected TimeSpan AGENT_PROVISIONING_TIMEOUT = TimeSpan.FromMinutes(5);
     protected string _poolName;
+    protected string _jobPrefix;
 
     public int ScheduledWorkerCount => _workers.Count();
+    protected string FormatJobName() => $"{_jobPrefix}-{_poolName}-{Guid.NewGuid().ToString().Substring(0, 4)}".ToLower();
     public virtual async Task UpdateDemand(int agentDemand)
     {
         // There appears to be X Job Requests that are not currently assigned to an agent that is idle

--- a/src/BaseHostService.cs
+++ b/src/BaseHostService.cs
@@ -5,7 +5,7 @@ public class BaseHostService
     protected string _poolName;
     protected string _jobPrefix;
 
-    public int ScheduledWorkerCount => _workers.Count();
+    public virtual int ScheduledWorkerCount => _workers.Count();
     protected string FormatJobName() => $"{_jobPrefix}-{_poolName}-{Guid.NewGuid().ToString().Substring(0, 4)}".ToLower();
     public virtual async Task UpdateDemand(int agentDemand)
     {
@@ -20,6 +20,7 @@ public class BaseHostService
                 try
                 {
                     var worker = await StartAgent();
+                    _workers.Add(worker);
                     Console.WriteLine($"Provisioned agent worker {worker.Id} to meet demand of {netAgentDemand}");
                 }
                 catch (Exception ex)
@@ -62,6 +63,7 @@ public class BaseHostService
             existingWorker.IsBusy = updatedAgent.IsBusy;
             updatedAgent.IsProvisioning = false;
         }
+        foreach (var worker in toDelete) _workers.Remove(worker);
         // Add any new workers that made their way into the pool
         _workers.AddRange(updatedAgents.Where(u => !_workers.Any(w => w.Id.StartsWith(u.Id))));
 

--- a/src/IAgentHostService.cs
+++ b/src/IAgentHostService.cs
@@ -14,6 +14,6 @@ public class WorkerAgent
 {
     public string Id {get;set;}
     public bool IsBusy {get;set;}
-    public bool IsProvisioning { get; internal set; }
-    public DateTime ProvisioningStart { get; internal set; }
+    public bool IsProvisioning { get; set; }
+    public DateTime ProvisioningStart { get; set; }
 }

--- a/src/IAgentHostService.cs
+++ b/src/IAgentHostService.cs
@@ -2,8 +2,17 @@ using System.Linq;
 
 public interface IAgentHostService
 {
-    Task<bool> IsJobProvisioned(long requestId);
-    Task StartAgent(long requestId, string agentPool);
+    Task UpdateDemand(int agentDemand);
+    Task<WorkerAgent> StartAgent();
     Task Initialize();
+    int ScheduledWorkerCount {get;}
+    Task UpdateWorkersState(IEnumerable<WorkerAgent> updatedAgents);
 }
 
+public class WorkerAgent 
+{
+    public string Id {get;set;}
+    public bool IsBusy {get;set;}
+    public bool IsProvisioning { get; internal set; }
+    public DateTime ProvisioningStart { get; internal set; }
+}

--- a/src/IAgentHostService.cs
+++ b/src/IAgentHostService.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using Microsoft.Extensions.Configuration;
 
 public interface IAgentHostService
 {

--- a/src/IFileSystem.cs
+++ b/src/IFileSystem.cs
@@ -3,5 +3,5 @@ public interface IFileSystem {
 }
 public class FileSystem : IFileSystem
 {
-    public string ReadAllText(string path) => File.ReadAllText(path);
+    public virtual string ReadAllText(string path) => File.ReadAllText(path);
 }

--- a/src/IFileSystem.cs
+++ b/src/IFileSystem.cs
@@ -1,0 +1,7 @@
+public interface IFileSystem {
+    string ReadAllText(string path);
+}
+public class FileSystem : IFileSystem
+{
+    public string ReadAllText(string path) => File.ReadAllText(path);
+}

--- a/src/KubernetesAgentHostService.cs
+++ b/src/KubernetesAgentHostService.cs
@@ -4,6 +4,7 @@ using k8s.Models;
 
 public class KubernetesAgentHostService : IAgentHostService
 {
+    private TimeSpan AGENT_PROVISIONING_TIMEOUT = TimeSpan.FromMinutes(5);
     private const string DEFAULT_JOB_PREFIX = "agent-job-";
     private string _namespace;
     private string _jobPrefix;
@@ -14,11 +15,13 @@ public class KubernetesAgentHostService : IAgentHostService
     private string _jobDefFile;
     private V1Job _predefinedJob;
     private Kubernetes _kubectl;
+    private string _poolName;
 
-    private string FormatJobName(long requestId) => $"{_jobPrefix}-{requestId}";
-    
 
-    public KubernetesAgentHostService(IConfiguration config)
+    private List<WorkerAgent> _workers = new List<WorkerAgent>();
+
+
+    public KubernetesAgentHostService(IConfiguration config, string poolName)
     {
         var kubeConfPath = config.GetValue<string>("KUBECONFIG", null);
         if (kubeConfPath == null) throw new ArgumentNullException("'KUBECONFIG' environment variable required but missing.");
@@ -31,7 +34,7 @@ public class KubernetesAgentHostService : IAgentHostService
         _azpPat = config.GetValue<string>("ORG_PAT");
         _dockerSockPath = config.GetValue<string>("JOB_DOCKER_SOCKET_PATH");
         _jobDefFile = config.GetValue<string>("JOB_DEFINITION_FILE");
-
+        _poolName = poolName;
         if (_jobDefFile != null)
         {
             _predefinedJob = KubernetesYaml.Deserialize<V1Job>(System.IO.File.ReadAllText(_jobDefFile));
@@ -52,17 +55,70 @@ public class KubernetesAgentHostService : IAgentHostService
             });
         }
     }
+    public async Task UpdateDemand(int agentDemand)
+    {
+        // There appears to be X Job Requests that are not currently assigned to an agent that is idle
+        // Let's assess the number of "Idle" or Provisioning agents vs the demand
+        var netAgentDemand = agentDemand - _workers.Count(w => w.IsProvisioning || !w.IsBusy);
+        if (netAgentDemand > 0)
+        {
+            // Not enough Agents to meet demand.. lets provision some!
+            for (var i = 0; i < netAgentDemand; i++)
+            {
+                var worker = await StartAgent();
+                Console.WriteLine($"Provisioned agent worker {worker.Id} to meet demand of {netAgentDemand}");
+            }
+        }
+        else if (netAgentDemand < 0)
+        {
+            // We have too many agents in relation to the demand.. lets cut back
+            Console.WriteLine($"There are currently over provisioned {netAgentDemand} agents");
+        }
+    }
+    public Task UpdateWorkersState(IEnumerable<WorkerAgent> updatedAgents)
+    {
+        // Remove any agents that have left the pool (as long as they're not provisioning and they're not present in updatedAgents)
+        // We exclude provisioning because sometimes it takes multiple seconds to provision an agent
+        List<WorkerAgent> toDelete = new List<WorkerAgent>();
+        foreach (var existingWorker in _workers)
+        {
+            // Check if Provisioning has taken too long
+            if (existingWorker.IsProvisioning && (DateTime.UtcNow - existingWorker.ProvisioningStart).TotalMinutes >= AGENT_PROVISIONING_TIMEOUT.TotalMinutes)
+            {
+                toDelete.Add(existingWorker);
+                continue;
+            }
 
-    public async Task<bool> IsJobProvisioned(long requestId) =>
-        (await _kubectl.ListNamespacedJobAsync(_namespace))
-            .Items.Any(x => x.Metadata.Name == FormatJobName(requestId));
+            // Check if agent no longer exists in the pool
+            var updatedAgent = updatedAgents.FirstOrDefault(a => a.Id.StartsWith(existingWorker.Id));
+            if (updatedAgent == null) // We use StartsWith here b/c K8s job pods have a suffix appended
+            {
+                toDelete.Add(existingWorker);
+                continue;
+            }
 
-    public async Task StartAgent(long requestId, string agentPool)
+            // Update existing WorkerAgent with updated state info
+            existingWorker.Id = updatedAgent.Id;
+            existingWorker.IsBusy = updatedAgent.IsBusy;
+            updatedAgent.IsProvisioning = false;
+        }
+        // Add any new workers that made their way into the pool
+        _workers.AddRange(updatedAgents.Where(u => !_workers.Any(w => w.Id.StartsWith(u.Id))));
+
+        return Task.CompletedTask;
+    }
+
+    public int ScheduledWorkerCount => _workers.Count;
+    private string FormatJobName() => $"{_jobPrefix}-{_poolName}-{Guid.NewGuid().ToString().Substring(0, 4)}".ToLower();
+
+
+    public async Task<WorkerAgent> StartAgent()
     {
         V1Job job = _predefinedJob;
+        var name = FormatJobName();
         if (_predefinedJob != null)
         {
-            _predefinedJob.Metadata.Name = FormatJobName(requestId);
+            _predefinedJob.Metadata.Name = name;
         }
         else
         {
@@ -72,7 +128,7 @@ public class KubernetesAgentHostService : IAgentHostService
                 Kind = "Job",
                 Metadata = new V1ObjectMeta()
                 {
-                    Name = FormatJobName(requestId),
+                    Name = name,
                     NamespaceProperty = _namespace
                 },
                 Spec = new V1JobSpec()
@@ -84,7 +140,7 @@ public class KubernetesAgentHostService : IAgentHostService
                             RestartPolicy = "Never",
                             Containers = new List<V1Container>(){
                             new V1Container() {
-                                Name = FormatJobName(requestId),
+                                Name = name,
                                 Image = _jobImage,
                                 Env = new List<V1EnvVar>() {
                                     new V1EnvVar() {
@@ -97,7 +153,7 @@ public class KubernetesAgentHostService : IAgentHostService
                                     },
                                     new V1EnvVar() {
                                         Name = "AZP_POOL",
-                                        Value = agentPool
+                                        Value = _poolName
                                     }
                                 }
                             }
@@ -116,23 +172,34 @@ public class KubernetesAgentHostService : IAgentHostService
                 var podSpec = job.Spec.Template.Spec;
                 var volumeName = "docker-volume";
 
-                podSpec.Volumes = new List<V1Volume>(){
-                new V1Volume() {
-                    Name = volumeName,
-                    HostPath = new V1HostPathVolumeSource() {
-                        Path = _dockerSockPath
+                podSpec.Volumes = new List<V1Volume>() {
+                    new V1Volume() {
+                        Name = volumeName,
+                        HostPath = new V1HostPathVolumeSource() {
+                            Path = _dockerSockPath
+                        }
                     }
-                }
-            };
+                };
 
                 podSpec.Containers[0].VolumeMounts = new List<V1VolumeMount>() {
-                new V1VolumeMount() {
-                    MountPath = _dockerSockPath,
-                    Name = volumeName
-                }
-            };
+                    new V1VolumeMount() {
+                        MountPath = _dockerSockPath,
+                        Name = volumeName
+                    }
+                };
             }
         }
-        await _kubectl.CreateNamespacedJobAsync(job, namespaceParameter: _namespace);
+
+        job = await _kubectl.CreateNamespacedJobAsync(job, namespaceParameter: _namespace);
+
+        WorkerAgent worker = null;
+        _workers.Add(worker = new WorkerAgent()
+        {
+            Id = name,
+            IsBusy = false,
+            IsProvisioning = true,
+            ProvisioningStart = DateTime.UtcNow
+        });
+        return worker;
     }
 }

--- a/src/KubernetesAgentHostService.cs
+++ b/src/KubernetesAgentHostService.cs
@@ -128,14 +128,12 @@ public class KubernetesAgentHostService : BaseHostService, IAgentHostService
 
         job = await _kubectl.CreateNamespacedJobAsync(job, namespaceParameter: _namespace);
 
-        WorkerAgent worker = null;
-        _workers.Add(worker = new WorkerAgent()
+        return new WorkerAgent()
         {
             Id = name,
             IsBusy = false,
             IsProvisioning = true,
             ProvisioningStart = DateTime.UtcNow
-        });
-        return worker;
+        };
     }
 }

--- a/src/KubernetesAgentHostService.cs
+++ b/src/KubernetesAgentHostService.cs
@@ -6,7 +6,6 @@ public class KubernetesAgentHostService : BaseHostService, IAgentHostService
 {
     private const string DEFAULT_JOB_PREFIX = "agent-job";
     private string _namespace;
-    private string _jobPrefix;
     private string _jobImage;
     private string _azpUrl;
     private string _azpPat;
@@ -49,10 +48,6 @@ public class KubernetesAgentHostService : BaseHostService, IAgentHostService
             });
         }
     }
-
-    public int ScheduledWorkerCount => _workers.Count;
-    private string FormatJobName() => $"{_jobPrefix}-{_poolName}-{Guid.NewGuid().ToString().Substring(0, 4)}".ToLower();
-
 
     public override async Task<WorkerAgent> StartAgent()
     {

--- a/src/KubernetesAgentHostService.cs
+++ b/src/KubernetesAgentHostService.cs
@@ -14,7 +14,7 @@ public class KubernetesAgentHostService : BaseHostService, IAgentHostService
     private V1Job _predefinedJob;
     private Kubernetes _kubectl;
 
-    public KubernetesAgentHostService(IConfiguration config, string poolName)
+    public KubernetesAgentHostService(IConfiguration config, IFileSystem fs, string poolName)
     {
         var kubeConfPath = config.GetValue<string>("KUBECONFIG", null);
         if (kubeConfPath == null) throw new ArgumentNullException("'KUBECONFIG' environment variable required but missing.");
@@ -30,7 +30,7 @@ public class KubernetesAgentHostService : BaseHostService, IAgentHostService
         _poolName = poolName;
         if (_jobDefFile != null)
         {
-            _predefinedJob = KubernetesYaml.Deserialize<V1Job>(System.IO.File.ReadAllText(_jobDefFile));
+            _predefinedJob = KubernetesYaml.Deserialize<V1Job>(fs.ReadAllText(_jobDefFile));
             _jobPrefix = _predefinedJob.Metadata.Name ?? _jobPrefix;
         }
     }

--- a/src/KubernetesAgentHostService.cs
+++ b/src/KubernetesAgentHostService.cs
@@ -2,10 +2,9 @@ using Microsoft.Extensions.Configuration;
 using k8s;
 using k8s.Models;
 
-public class KubernetesAgentHostService : IAgentHostService
+public class KubernetesAgentHostService : BaseHostService, IAgentHostService
 {
-    private TimeSpan AGENT_PROVISIONING_TIMEOUT = TimeSpan.FromMinutes(5);
-    private const string DEFAULT_JOB_PREFIX = "agent-job-";
+    private const string DEFAULT_JOB_PREFIX = "agent-job";
     private string _namespace;
     private string _jobPrefix;
     private string _jobImage;
@@ -15,11 +14,6 @@ public class KubernetesAgentHostService : IAgentHostService
     private string _jobDefFile;
     private V1Job _predefinedJob;
     private Kubernetes _kubectl;
-    private string _poolName;
-
-
-    private List<WorkerAgent> _workers = new List<WorkerAgent>();
-
 
     public KubernetesAgentHostService(IConfiguration config, string poolName)
     {
@@ -55,64 +49,12 @@ public class KubernetesAgentHostService : IAgentHostService
             });
         }
     }
-    public async Task UpdateDemand(int agentDemand)
-    {
-        // There appears to be X Job Requests that are not currently assigned to an agent that is idle
-        // Let's assess the number of "Idle" or Provisioning agents vs the demand
-        var netAgentDemand = agentDemand - _workers.Count(w => w.IsProvisioning || !w.IsBusy);
-        if (netAgentDemand > 0)
-        {
-            // Not enough Agents to meet demand.. lets provision some!
-            for (var i = 0; i < netAgentDemand; i++)
-            {
-                var worker = await StartAgent();
-                Console.WriteLine($"Provisioned agent worker {worker.Id} to meet demand of {netAgentDemand}");
-            }
-        }
-        else if (netAgentDemand < 0)
-        {
-            // We have too many agents in relation to the demand.. lets cut back
-            Console.WriteLine($"There are currently over provisioned {netAgentDemand} agents");
-        }
-    }
-    public Task UpdateWorkersState(IEnumerable<WorkerAgent> updatedAgents)
-    {
-        // Remove any agents that have left the pool (as long as they're not provisioning and they're not present in updatedAgents)
-        // We exclude provisioning because sometimes it takes multiple seconds to provision an agent
-        List<WorkerAgent> toDelete = new List<WorkerAgent>();
-        foreach (var existingWorker in _workers)
-        {
-            // Check if Provisioning has taken too long
-            if (existingWorker.IsProvisioning && (DateTime.UtcNow - existingWorker.ProvisioningStart).TotalMinutes >= AGENT_PROVISIONING_TIMEOUT.TotalMinutes)
-            {
-                toDelete.Add(existingWorker);
-                continue;
-            }
-
-            // Check if agent no longer exists in the pool
-            var updatedAgent = updatedAgents.FirstOrDefault(a => a.Id.StartsWith(existingWorker.Id));
-            if (updatedAgent == null) // We use StartsWith here b/c K8s job pods have a suffix appended
-            {
-                toDelete.Add(existingWorker);
-                continue;
-            }
-
-            // Update existing WorkerAgent with updated state info
-            existingWorker.Id = updatedAgent.Id;
-            existingWorker.IsBusy = updatedAgent.IsBusy;
-            updatedAgent.IsProvisioning = false;
-        }
-        // Add any new workers that made their way into the pool
-        _workers.AddRange(updatedAgents.Where(u => !_workers.Any(w => w.Id.StartsWith(u.Id))));
-
-        return Task.CompletedTask;
-    }
 
     public int ScheduledWorkerCount => _workers.Count;
     private string FormatJobName() => $"{_jobPrefix}-{_poolName}-{Guid.NewGuid().ToString().Substring(0, 4)}".ToLower();
 
 
-    public async Task<WorkerAgent> StartAgent()
+    public override async Task<WorkerAgent> StartAgent()
     {
         V1Job job = _predefinedJob;
         var name = FormatJobName();

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -44,12 +44,13 @@ while (true)
                     hostService = new KubernetesAgentHostService(config, agentPoolName);
                     hostServices.Add(agentPoolName, hostService);
                     break;
-                    /*
+                    
                 case "aci":
                 case "azurecontainerinstance":
                 case "azurecontainerinstances":
-                    hostService = new ACIAgentHostService(config);
-                    break;*/
+                    hostService = new ACIAgentHostService(config, agentPoolName);
+                    break;
+
                 default:
                     throw new Exception($"Host type [{agentHostType}] is not valid.");
             }
@@ -63,7 +64,8 @@ while (true)
             Console.WriteLine($"Could not locate agent pool named [{agentPoolName}].");
             continue;
         }
-        var agents = (await DistributedTask.GetAgentsAsync(agentPool.Id, includeAssignedRequest: true)).Where(a => a.Status == TaskAgentStatus.Online);
+        var agents = (await DistributedTask.GetAgentsAsync(agentPool.Id, includeAssignedRequest: true))
+            .Where(a => a.Status == TaskAgentStatus.Online && a.Enabled == true);
 
         // Let our host service know which agents are currently online.. it will trim out any workers that have gone offline
         await hostService.UpdateWorkersState(agents.Select(a => new WorkerAgent()

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -41,7 +41,7 @@ while (true)
             {
                 case "kubernetes":
                 case "k8s":
-                    hostService = new KubernetesAgentHostService(config, agentPoolName);
+                    hostService = new KubernetesAgentHostService(config, new FileSystem(), agentPoolName);
                     hostServices.Add(agentPoolName, hostService);
                     break;
                     

--- a/tests/ADOAgentOrchestrator.Tests.csproj
+++ b/tests/ADOAgentOrchestrator.Tests.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="Moq" Version="4.18.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
     <PackageReference Include="coverlet.collector" Version="3.1.2" />

--- a/tests/ADOAgentOrchestrator.Tests.csproj
+++ b/tests/ADOAgentOrchestrator.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="JunitXml.TestLogger" Version="3.0.114" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="Moq" Version="4.18.1" />

--- a/tests/KubernetesAgentHostTests.cs
+++ b/tests/KubernetesAgentHostTests.cs
@@ -1,14 +1,66 @@
 namespace ADOAgentOrchestrator.Tests;
 
+
+
 [TestClass]
 public class KubernetesAgentHostTests
 {
+    static string testYaml = $@"
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: custom-job
+spec:
+  template:
+    spec:
+      containers:
+      - name: custom-job
+        image: ghcr.io/akanieski/ado-pipelines-linux:0.0.1-preview
+        volumeMounts:
+          - mountPath: /var/run/docker.sock
+            name: docker-volume
+        resources:
+          requests:
+            memory: ""1000Mi""
+            cpu: ""1000m""
+          limits:
+            memory: ""2000Mi""
+            cpu: ""2000m""
+        env:
+          - name: AZP_URL
+            value: https://dev.azure.com/devops-collab
+          - name: AZP_TOKEN
+            value: some_token
+          - name: AZP_POOL
+            value: Default
+      restartPolicy: Never
+      volumes:
+        - name: docker-volume
+          hostPath:
+            path: /var/run/docker.sock
+";
+    private class MockFileSystem : IFileSystem
+    {
+        public int CallCount = 0;
+        public string ReadAllText(string path) { 
+            CallCount++;
+            return testYaml;
+        }
+    }
     [TestMethod]
     public void RequireKubeConfig()
     {
-        var config = new ConfigurationBuilder().Build();
-        Assert.ThrowsException<ArgumentNullException>(() => {
-            var _ =  new KubernetesAgentHostService(config, string.Empty);
-        });
+        var config = new ConfigurationBuilder()
+        .AddInMemoryCollection(new Dictionary<string, string>() {
+            {"KUBECONFIG", "~/.kube/config"},
+            {"JOB_DEFINITION_FILE", "./JobDef.yaml"},
+
+        }.ToList())
+        .Build();
+
+        var mockFs = new MockFileSystem();
+        var svc =  new KubernetesAgentHostService(config, mockFs, string.Empty);
+
+        Assert.AreEqual(1, mockFs.CallCount, "Should fetch jod definition from disk when provided.");
     }
 }

--- a/tests/KubernetesAgentHostTests.cs
+++ b/tests/KubernetesAgentHostTests.cs
@@ -1,11 +1,136 @@
 namespace ADOAgentOrchestrator.Tests;
-
+using Moq;
 
 
 [TestClass]
 public class KubernetesAgentHostTests
 {
-    static string testYaml = $@"
+    [TestMethod]
+    public void ShouldReadFromJobDefinition()
+    {
+        var jobDefFileName = "./JobDef.yaml";
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string>() {
+                {"JOB_DEFINITION_FILE", jobDefFileName},
+            }.ToList())
+            .Build();
+        var mockFs = new Mock<FileSystem>();
+        mockFs.Setup(f => f.ReadAllText(jobDefFileName)).Returns(JobDefYaml);
+
+        var svcMock =  new Mock<KubernetesAgentHostService>(MockBehavior.Strict, config, mockFs.Object, string.Empty);
+        var svcConcrete = svcMock.Object;
+
+        mockFs.Verify(x => x.ReadAllText(jobDefFileName), Times.Once, "Should fetch jod definition from disk when provided.");
+    }
+    [TestMethod]
+    public async Task ShouldUpdateWorkerState()
+    {
+        var config = new ConfigurationBuilder().Build();
+
+        var svcMock =  new Mock<KubernetesAgentHostService>(config, new FileSystem(), "agentPool");
+        svcMock.SetupGet(x => x.ScheduledWorkerCount).CallBase();
+        svcMock.Setup(x => x.UpdateWorkersState(It.IsAny<List<WorkerAgent>>())).CallBase();
+        svcMock.Setup(x => x.StartAgent()).Returns(Task.FromResult(new WorkerAgent() {
+            Id = "Worker2",
+            IsProvisioning = true
+        }));
+        var svcConcrete = svcMock.Object;
+        await svcConcrete.UpdateWorkersState(new List<WorkerAgent>() {
+            new WorkerAgent() {
+                Id = "Worker1"
+            }
+        });
+        
+        Assert.AreEqual(1, svcConcrete.ScheduledWorkerCount, "Should add new workers");
+
+        await svcConcrete.UpdateWorkersState(new List<WorkerAgent>() {
+            new WorkerAgent() {
+                Id = "Worker1",
+                IsBusy = true
+            }
+        });
+        Assert.AreEqual(1, svcConcrete.ScheduledWorkerCount, "Should not add duplicate new workers");
+        
+
+        await svcConcrete.UpdateWorkersState(new List<WorkerAgent>() { });
+        Assert.AreEqual(0, svcConcrete.ScheduledWorkerCount, "Should remove workers that are no longer present");
+    }
+    [TestMethod]
+    public async Task ShouldProvisionNewAgent_AsNeeded()
+    {
+        var config = new ConfigurationBuilder().Build();
+
+        var svcMock =  new Mock<KubernetesAgentHostService>(config, new FileSystem(), "agentPool");
+        svcMock.SetupGet(x => x.ScheduledWorkerCount).CallBase();
+        svcMock.Setup(x => x.UpdateDemand(It.IsAny<int>())).CallBase();
+        svcMock.Setup(x => x.StartAgent()).Returns(Task.FromResult(new WorkerAgent() {
+            Id = "Worker2",
+            IsProvisioning = true
+        }));
+        var svcConcrete = svcMock.Object;
+        
+        await svcConcrete.UpdateDemand(1);
+
+        Assert.AreEqual(1, svcConcrete.ScheduledWorkerCount, "Should add new workers");
+    }
+
+    [TestMethod]
+    public async Task ShouldProvisionNewAgent_IfExistingAreBusy()
+    {
+        var config = new ConfigurationBuilder().Build();
+
+        var svcMock =  new Mock<KubernetesAgentHostService>(config, new FileSystem(), "agentPool");
+        svcMock.SetupGet(x => x.ScheduledWorkerCount).CallBase();
+        svcMock.Setup(x => x.UpdateDemand(It.IsAny<int>())).CallBase();
+        svcMock.Setup(x => x.UpdateWorkersState(It.IsAny<List<WorkerAgent>>())).CallBase();
+        svcMock.Setup(x => x.StartAgent()).Returns(Task.FromResult(new WorkerAgent() {
+            Id = "Worker2",
+            IsProvisioning = true
+        }));
+        var svcConcrete = svcMock.Object;
+        // Place an existing worker into agents
+        await svcConcrete.UpdateWorkersState(new List<WorkerAgent>() {
+            new WorkerAgent() {
+                Id = "Worker1",
+                IsBusy = true
+            }
+        });
+        
+        await svcConcrete.UpdateDemand(1);
+
+        Assert.AreEqual(2, svcConcrete.ScheduledWorkerCount, "Should add new workers if existing are busy");
+    }
+
+    [TestMethod]
+    public async Task ShouldNotProvisionNewAgent_IfExistingAreProvisioning()
+    {
+        var config = new ConfigurationBuilder().Build();
+
+        var svcMock =  new Mock<KubernetesAgentHostService>(config, new FileSystem(), "agentPool");
+        svcMock.SetupGet(x => x.ScheduledWorkerCount).CallBase();
+        svcMock.Setup(x => x.UpdateDemand(It.IsAny<int>())).CallBase();
+        svcMock.Setup(x => x.UpdateWorkersState(It.IsAny<List<WorkerAgent>>())).CallBase();
+        svcMock.Setup(x => x.StartAgent()).Returns(Task.FromResult(new WorkerAgent() {
+            Id = "Worker2",
+            IsProvisioning = true
+        }));
+        var svcConcrete = svcMock.Object;
+        // Place an existing worker into agents
+        await svcConcrete.UpdateWorkersState(new List<WorkerAgent>() {
+            new WorkerAgent() {
+                Id = "Worker1",
+                IsBusy = false,
+                IsProvisioning = true
+            }
+        });
+        
+        await svcConcrete.UpdateDemand(1);
+
+        Assert.AreEqual(1, svcConcrete.ScheduledWorkerCount, "Should NOT add new workers if existing is provisioning");
+    }
+
+
+    private string JobDefYaml = $@"
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -39,26 +164,4 @@ spec:
           hostPath:
             path: /var/run/docker.sock
 ";
-    private class MockFileSystem : IFileSystem
-    {
-        public int CallCount = 0;
-        public string ReadAllText(string path) { 
-            CallCount++;
-            return testYaml;
-        }
-    }
-    [TestMethod]
-    public void RequireKubeConfig()
-    {
-        var config = new ConfigurationBuilder()
-        .AddInMemoryCollection(new Dictionary<string, string>() {
-            {"JOB_DEFINITION_FILE", "./JobDef.yaml"},
-        }.ToList())
-        .Build();
-
-        var mockFs = new MockFileSystem();
-        var svc =  new KubernetesAgentHostService(config, mockFs, string.Empty);
-
-        Assert.AreEqual(1, mockFs.CallCount, "Should fetch jod definition from disk when provided.");
-    }
 }

--- a/tests/KubernetesAgentHostTests.cs
+++ b/tests/KubernetesAgentHostTests.cs
@@ -8,7 +8,7 @@ public class KubernetesAgentHostTests
     {
         var config = new ConfigurationBuilder().Build();
         Assert.ThrowsException<ArgumentNullException>(() => {
-            var _ =  new KubernetesAgentHostService(config);
+            var _ =  new KubernetesAgentHostService(config, string.Empty);
         });
     }
 }


### PR DESCRIPTION
Determining if there is a need to provision more agents to meet the demand requires some thought. Today the orchestrator first looks at existing job requests on a given pool and checks to see if all the job requests have either no reserved agent, or has a reserved agent but it's busy. In which case it will provision additional agents.

But today we attempt to avoid over provisioning agents by naming an agent job (k8s) after the requestId that trigger the demand. This is deceptive since the actual RequestID that the agent may pick it can be totally different from the RequestId that triggered its provisioning.

This leads to "zombie" agents that are waiting around for work, even though no work is queued.

I propose we complete disconnect the relation between an agent and the specific request that triggered it's provisioning, and treat the entire pool and entire queue as a homogeneous pool. The major downside of this approach is that the pool may have ample agents available, but none that meet the demands of the Pipeline thats running.

This needs further thought. Commentary is welcome!